### PR TITLE
feat: frontend app shell for match feature (auth/profile context, nav, test infra)

### DIFF
--- a/vifrost/package-lock.json
+++ b/vifrost/package-lock.json
@@ -43,10 +43,63 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^29.1.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^4.1.6"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -547,6 +600,19 @@
         }
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
@@ -666,6 +732,146 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -1407,6 +1613,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2262,6 +2486,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.105.4",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.4.tgz",
@@ -2721,6 +2952,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3132,6 +3381,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3266,6 +3628,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -3292,6 +3664,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/body-parser": {
@@ -3455,6 +3837,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3770,6 +4162,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3798,6 +4204,20 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3814,6 +4234,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -3995,6 +4422,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -4030,6 +4470,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4299,6 +4746,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4363,6 +4820,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -4934,6 +5401,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -5192,6 +5672,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -5289,6 +5776,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -5747,6 +6285,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -6071,6 +6616,20 @@
         "node": ">= 10"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -6260,6 +6819,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6298,6 +6870,13 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -6770,6 +7349,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -6989,6 +7581,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7035,6 +7634,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -7043,6 +7649,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -7164,6 +7777,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -7217,6 +7837,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7231,6 +7868,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -7282,6 +7929,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7414,6 +8074,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -7609,11 +8279,114 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -7622,6 +8395,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -7637,6 +8445,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -7725,6 +8550,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/vifrost/package.json
+++ b/vifrost/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
@@ -45,8 +46,10 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.1.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.1.6"
   }
 }

--- a/vifrost/src/components/Navbar.css
+++ b/vifrost/src/components/Navbar.css
@@ -1,5 +1,5 @@
 .navbar {
-    background: rgba(44, 81, 76, 0.85);
+    background: rgba(30, 96, 88, 0.88);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     display: flex;
@@ -12,6 +12,10 @@
     flex-shrink: 0;
     position: relative;
     z-index: 10;
+}
+
+.dark .navbar {
+    background: rgba(44, 81, 76, 0.85);
 }
 
 /* Left: Logo */
@@ -151,70 +155,21 @@
     letter-spacing: 0.04em;
 }
 
-.navbar-user-wrapper {
-    position: relative;
-}
-
-.navbar-dropdown {
-    position: absolute;
-    top: calc(100% + 8px);
-    right: 0;
-    min-width: 160px;
-    background: rgba(24, 36, 34, 0.97);
-    border: 1px solid rgba(237, 232, 245, 0.12);
-    border-radius: 8px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-    display: flex;
-    flex-direction: column;
-    padding: 4px;
-    z-index: 100;
-}
-
-.navbar-dropdown-item {
-    font-family: "JetBrains Mono", monospace;
-    font-size: 0.82rem;
-    font-weight: 500;
-    letter-spacing: 0.03em;
-    color: #ede8f5;
-    background: none;
-    border: none;
-    text-align: left;
-    padding: 8px 12px;
-    border-radius: 5px;
-    cursor: pointer;
-    transition: background 0.15s;
-}
-
-.navbar-dropdown-item:hover {
-    background: rgba(255, 255, 255, 0.08);
-}
-
-.navbar-dropdown-item--danger {
-    color: #f87171;
-}
-
-.navbar-dropdown-item--danger:hover {
-    background: rgba(248, 113, 113, 0.12);
-}
-
-.navbar-dropdown-divider {
-    height: 1px;
-    background: rgba(237, 232, 245, 0.1);
-    margin: 4px 0;
-}
 
 .navbar-avatar {
     width: 26px;
     height: 26px;
     border-radius: 50%;
     background: var(--colorCyan);
-    color: #0a0e14;
+    color: #ffffff;
     font-size: 0.75rem;
     font-weight: 800;
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
+}
+
+.dark .navbar-avatar {
+    color: #0a0e14;
 }

--- a/vifrost/src/components/Navbar.tsx
+++ b/vifrost/src/components/Navbar.tsx
@@ -1,6 +1,18 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  UserCircleIcon,
+  Clock01Icon,
+  Logout03Icon,
+  DashboardSquare01Icon,
+} from "@hugeicons/core-free-icons";
 import { useProfile } from "@/contexts/ProfileContext";
 import { AnimatedThemeToggler } from "./ui/animated-theme-toggler";
 import "./Navbar.css";
@@ -29,22 +41,21 @@ function AuthButtons() {
   );
 }
 
+// shared shadcn-style menu-item classes for the popover panel. neutral
+// hover overlay (not bg-accent) so it reads on the app's teal panel.
+const MENU_ITEM =
+  "flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 " +
+  "text-left text-sm transition-colors outline-none hover:bg-white/10 " +
+  "focus-visible:bg-white/10";
+
 function AvatarDropdown({ username }: { username: string }) {
   const navigate = useNavigate();
   const { signOut } = useAuth();
+  // controlled so selecting an item closes the panel. base-ui's popover owns
+  // outside-click / escape / focus return, so the old manual mousedown
+  // listener + wrapper ref are gone.
   const { isAdmin } = useProfile();
   const [open, setOpen] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
 
   const go = (path: string) => {
     setOpen(false);
@@ -52,55 +63,59 @@ function AvatarDropdown({ username }: { username: string }) {
   };
 
   return (
-    <div className="navbar-user-wrapper" ref={wrapperRef}>
-      <button
-        type="button"
-        className="navbar-user-btn"
-        title="Profile"
-        onClick={() => setOpen((p) => !p)}
-      >
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger className="navbar-user-btn" title="Profile">
         <div className="navbar-avatar">{username[0]?.toUpperCase() ?? "?"}</div>
         <span className="navbar-username">{username}</span>
-      </button>
-      {open ? (
-        <div className="navbar-dropdown">
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="w-48 gap-0 rounded-xl border border-[var(--colorBorder)] bg-[var(--colorSurfaceAlt)] p-1 text-[var(--colorText)] ring-0"
+      >
+        <button type="button" className={MENU_ITEM} onClick={() => go("/profile")}>
+          <HugeiconsIcon icon={UserCircleIcon} size={17} strokeWidth={2} />
+          Profile
+        </button>
+        <button
+          type="button"
+          className={MENU_ITEM}
+          onClick={() => go("/match-history")}
+        >
+          <HugeiconsIcon icon={Clock01Icon} size={17} strokeWidth={2} />
+          Match History
+        </button>
+        {isAdmin ? (
           <button
             type="button"
-            className="navbar-dropdown-item"
-            onClick={() => go("/profile")}
+            className={MENU_ITEM}
+            onClick={() => go("/admin/dashboard")}
           >
-            Profile
+            <HugeiconsIcon
+              icon={DashboardSquare01Icon}
+              size={17}
+              strokeWidth={2}
+            />
+            Admin dashboard
           </button>
-          <button
-            type="button"
-            className="navbar-dropdown-item"
-            onClick={() => go("/match-history")}
-          >
-            Match History
-          </button>
-          {isAdmin ? (
-            <button
-              type="button"
-              className="navbar-dropdown-item"
-              onClick={() => go("/admin/dashboard")}
-            >
-              Admin dashboard
-            </button>
-          ) : null}
-          <div className="navbar-dropdown-divider" />
-          <button
-            type="button"
-            className="navbar-dropdown-item navbar-dropdown-item--danger"
-            onClick={() => {
-              setOpen(false);
-              void signOut();
-            }}
-          >
-            Sign Out
-          </button>
-        </div>
-      ) : null}
-    </div>
+        ) : null}
+        <div className="my-1 h-px bg-[var(--colorBorder)]" />
+        <button
+          type="button"
+          className={
+            MENU_ITEM +
+            " text-destructive hover:bg-destructive/10 hover:text-destructive"
+          }
+          onClick={() => {
+            setOpen(false);
+            void signOut();
+          }}
+        >
+          <HugeiconsIcon icon={Logout03Icon} size={17} strokeWidth={2} />
+          Sign Out
+        </button>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/vifrost/src/components/ui/popover.tsx
+++ b/vifrost/src/components/ui/popover.tsx
@@ -1,0 +1,90 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  anchor,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "anchor"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        anchor={anchor}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-4 rounded-2xl bg-popover p-4 text-sm text-popover-foreground shadow-2xl ring-1 ring-foreground/5 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn("text-base font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: PopoverPrimitive.Description.Props) {
+  return (
+    <PopoverPrimitive.Description
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+}

--- a/vifrost/src/contexts/AuthContext.tsx
+++ b/vifrost/src/contexts/AuthContext.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase";
+import { readPersistedSession } from "@/lib/persistedSession";
 
 export type AuthContextValue = {
   session: Session | null;
@@ -32,8 +33,15 @@ function slugFromEmail(email: string): string {
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [session, setSession] = useState<Session | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const initialSession = useMemo(
+    () =>
+      typeof localStorage !== "undefined"
+        ? readPersistedSession(localStorage)
+        : null,
+    [],
+  );
+  const [session, setSession] = useState<Session | null>(initialSession);
+  const [isLoading, setIsLoading] = useState(initialSession === null);
 
   useEffect(() => {
     const sb = supabase

--- a/vifrost/src/contexts/ProfileContext.tsx
+++ b/vifrost/src/contexts/ProfileContext.tsx
@@ -10,6 +10,11 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useAuth } from "@/contexts/AuthContext"
 import { canAccessPlatform, isAdmin } from "@/lib/access"
 import { fetchProfile } from "@/services/profileService"
+import {
+  readPersistedProfile,
+  writePersistedProfile,
+  clearPersistedProfile,
+} from "@/lib/persistedProfile"
 import type { Profile } from "@/types/profile"
 
 export type ProfileContextValue = {
@@ -21,6 +26,10 @@ export type ProfileContextValue = {
   refreshProfile: () => Promise<void>
 }
 
+// localStorage is a stable per-origin singleton; resolve it once at
+// module scope so it never churns hook dependency arrays.
+const LS = typeof localStorage !== "undefined" ? localStorage : null
+
 const ProfileContext = createContext<ProfileContextValue | null>(null)
 
 export const profileQueryKey = (userId: string | undefined) =>
@@ -31,15 +40,24 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient()
   const userId = user?.id
 
+  // seed synchronously from the last persisted profile so an
+  // already-logged-in refresh renders without the full-page loader.
+  // the stale savedAt makes react-query treat it as stale and
+  // background-revalidate immediately; the ban effect still corrects.
+  const seeded = useMemo(() => readPersistedProfile(LS, userId), [userId])
+
   const {
     data: profile = null,
     isLoading,
     error,
     refetch,
+    dataUpdatedAt,
   } = useQuery({
     queryKey: profileQueryKey(userId),
     queryFn: () => fetchProfile(userId!),
     enabled: Boolean(userId),
+    initialData: seeded ? seeded.profile : undefined,
+    initialDataUpdatedAt: seeded ? seeded.savedAt : undefined,
   })
 
   useEffect(() => {
@@ -48,6 +66,21 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
       void signOut()
     }
   }, [user, profile, isLoading, signOut])
+
+  // mirror fresh query results into persisted storage so the next
+  // reload can seed from them. clear it when the server says there is
+  // no profile so we never seed a deleted one.
+  useEffect(() => {
+    if (!userId || isLoading) return
+    // only persist data that actually came from a server fetch, not the
+    // seeded value: rewriting the seed would bump savedAt and, because
+    // the global staleTime is 30s, suppress the next reload's
+    // revalidation. dataUpdatedAt only exceeds the seed's savedAt after
+    // a real fetch resolves.
+    if (dataUpdatedAt <= (seeded?.savedAt ?? 0)) return
+    if (profile) writePersistedProfile(LS, userId, profile)
+    else clearPersistedProfile(LS)
+  }, [userId, isLoading, profile, dataUpdatedAt, seeded])
 
   const refreshProfile = useCallback(async () => {
     await refetch()
@@ -65,9 +98,14 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     [profile, userId, isLoading, error, refreshProfile],
   )
 
+  // on sign-out clear the single shared profile key. note this is one
+  // key per origin, so signing out drops any other tab's cached profile
+  // too; cross-user reads are still safe because readPersistedProfile
+  // matches on userId.
   useEffect(() => {
     if (!userId) {
       queryClient.removeQueries({ queryKey: ["profile"] })
+      clearPersistedProfile(LS)
     }
   }, [userId, queryClient])
 

--- a/vifrost/src/lib/persistedProfile.test.ts
+++ b/vifrost/src/lib/persistedProfile.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  readPersistedProfile,
+  writePersistedProfile,
+  clearPersistedProfile,
+} from "./persistedProfile";
+import type { Profile } from "@/types/profile";
+
+// in-memory Storage-like with a mutable backing map.
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    get length() {
+      return map.size;
+    },
+    key: (i: number) => [...map.keys()][i] ?? null,
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    _map: map,
+  };
+}
+
+const NOW = 1_700_000_000_000;
+
+const profile: Profile = {
+  id: "user-1",
+  email: "a@b.c",
+  full_name: "A B",
+  role: "user",
+  status: "approved",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-02T00:00:00Z",
+  rating: 400,
+  peak_rating: 400,
+  wins: 0,
+  losses: 0,
+  ties: 0,
+  current_streak: 0,
+};
+
+describe("persistedProfile", () => {
+  it("returns null when storage is null/undefined", () => {
+    expect(readPersistedProfile(null, "user-1", NOW)).toBeNull();
+    expect(readPersistedProfile(undefined, "user-1", NOW)).toBeNull();
+  });
+
+  it("returns null when no userId is given", () => {
+    const s = fakeStorage();
+    writePersistedProfile(s, "user-1", profile, NOW);
+    expect(readPersistedProfile(s, undefined, NOW)).toBeNull();
+  });
+
+  it("round-trips a written profile for the same user", () => {
+    const s = fakeStorage();
+    writePersistedProfile(s, "user-1", profile, NOW);
+    const out = readPersistedProfile(s, "user-1", NOW);
+    expect(out).not.toBeNull();
+    expect(out!.profile).toEqual(profile);
+    expect(out!.savedAt).toBe(NOW);
+  });
+
+  it("does not return another user's cached profile", () => {
+    const s = fakeStorage();
+    writePersistedProfile(s, "user-1", profile, NOW);
+    expect(readPersistedProfile(s, "user-2", NOW)).toBeNull();
+  });
+
+  it("returns null for malformed stored JSON", () => {
+    const s = fakeStorage({ "vifrost.profile": "{nope" });
+    expect(readPersistedProfile(s, "user-1", NOW)).toBeNull();
+  });
+
+  it("rejects a cached blob missing required fields (email/role)", () => {
+    const s = fakeStorage({
+      "vifrost.profile": JSON.stringify({
+        userId: "user-1",
+        savedAt: NOW,
+        profile: { id: "user-1", status: "approved" },
+      }),
+    });
+    expect(readPersistedProfile(s, "user-1", NOW)).toBeNull();
+  });
+
+  it("returns null when the cache is older than maxAgeMs", () => {
+    const s = fakeStorage();
+    writePersistedProfile(s, "user-1", profile, NOW - 10_000);
+    expect(readPersistedProfile(s, "user-1", NOW, 5_000)).toBeNull();
+    // within the window it is still returned
+    expect(readPersistedProfile(s, "user-1", NOW, 20_000)).not.toBeNull();
+  });
+
+  it("clearPersistedProfile removes the entry", () => {
+    const s = fakeStorage();
+    writePersistedProfile(s, "user-1", profile, NOW);
+    clearPersistedProfile(s);
+    expect(readPersistedProfile(s, "user-1", NOW)).toBeNull();
+  });
+
+  it("never throws if storage access fails", () => {
+    const throwing = {
+      get length(): number {
+        throw new Error("denied");
+      },
+      key: () => null,
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+      removeItem: () => {
+        throw new Error("denied");
+      },
+    };
+    expect(() => readPersistedProfile(throwing, "user-1", NOW)).not.toThrow();
+    expect(readPersistedProfile(throwing, "user-1", NOW)).toBeNull();
+    expect(() =>
+      writePersistedProfile(throwing, "user-1", profile, NOW),
+    ).not.toThrow();
+    expect(() => clearPersistedProfile(throwing)).not.toThrow();
+  });
+});

--- a/vifrost/src/lib/persistedProfile.ts
+++ b/vifrost/src/lib/persistedProfile.ts
@@ -1,0 +1,90 @@
+import type { Profile } from "@/types/profile"
+
+// the profile react-query has no cross-reload cache, so every refresh
+// refetches it over the network while ProtectedRoute shows a full-page
+// loader (the "quick flash"). persisting the last-known profile lets the
+// query seed `initialData` synchronously so the first paint is already
+// rendered; react-query still background-revalidates and the existing
+// ban effect still corrects. symmetric with readPersistedSession.
+
+const PROFILE_KEY = "vifrost.profile"
+
+// generous bound: a seed older than this is ignored so a long-offline
+// reload doesn't render very stale status. normal use revalidates in
+// well under a second, so this only matters for stale/offline edges.
+const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+type StorageLike = {
+  length: number
+  key(index: number): string | null
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+type Stored = { userId: string; profile: Profile; savedAt: number }
+
+function isProfile(v: unknown): v is Profile {
+  if (!v || typeof v !== "object") return false
+  const p = v as Record<string, unknown>
+  // a cached profile can only originate from a real fetch, so a thin
+  // check is enough — but validate the fields consumers actually read
+  // (status/role gate access; email/id identify) so a corrupt blob is
+  // dropped rather than seeded.
+  return (
+    typeof p.id === "string" &&
+    typeof p.email === "string" &&
+    typeof p.role === "string" &&
+    typeof p.status === "string"
+  )
+}
+
+export function readPersistedProfile(
+  storage: StorageLike | null | undefined,
+  userId: string | undefined,
+  nowMs: number = Date.now(),
+  maxAgeMs: number = DEFAULT_MAX_AGE_MS,
+): { profile: Profile; savedAt: number } | null {
+  if (!storage || !userId) return null
+  try {
+    const raw = storage.getItem(PROFILE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== "object") return null
+    const s = parsed as Partial<Stored>
+    if (s.userId !== userId) return null
+    if (typeof s.savedAt !== "number") return null
+    if (nowMs - s.savedAt > maxAgeMs) return null
+    if (!isProfile(s.profile)) return null
+    return { profile: s.profile, savedAt: s.savedAt }
+  } catch {
+    return null
+  }
+}
+
+export function writePersistedProfile(
+  storage: StorageLike | null | undefined,
+  userId: string | undefined,
+  profile: Profile,
+  nowMs: number = Date.now(),
+): void {
+  if (!storage || !userId) return
+  try {
+    const payload: Stored = { userId, profile, savedAt: nowMs }
+    storage.setItem(PROFILE_KEY, JSON.stringify(payload))
+  } catch {
+    // storage unavailable (private mode / quota) — the in-memory query
+    // still works; we just lose the cross-reload optimization.
+  }
+}
+
+export function clearPersistedProfile(
+  storage: StorageLike | null | undefined,
+): void {
+  if (!storage) return
+  try {
+    storage.removeItem(PROFILE_KEY)
+  } catch {
+    // ignore — see writePersistedProfile.
+  }
+}

--- a/vifrost/src/lib/persistedSession.test.ts
+++ b/vifrost/src/lib/persistedSession.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { readPersistedSession } from "./persistedSession";
+
+// minimal in-memory Storage-like for the synchronous read.
+function fakeStorage(entries: Record<string, string>) {
+  const keys = Object.keys(entries);
+  return {
+    length: keys.length,
+    key: (i: number) => keys[i] ?? null,
+    getItem: (k: string) => (k in entries ? entries[k] : null),
+  };
+}
+
+const NOW = 1_700_000_000_000; // fixed "now" in ms
+const future = Math.floor(NOW / 1000) + 3600; // unix seconds, +1h
+const past = Math.floor(NOW / 1000) - 3600; // unix seconds, -1h
+
+function sessionJson(expires_at: number) {
+  return JSON.stringify({
+    access_token: "at",
+    refresh_token: "rt",
+    expires_at,
+    token_type: "bearer",
+    user: { id: "u1", email: "a@b.c" },
+  });
+}
+
+describe("readPersistedSession", () => {
+  it("returns null when storage is null/undefined", () => {
+    expect(readPersistedSession(null, NOW)).toBeNull();
+    expect(readPersistedSession(undefined, NOW)).toBeNull();
+  });
+
+  it("returns null when no sb-*-auth-token key exists", () => {
+    const s = fakeStorage({ "unrelated-key": "x", "username": "joe" });
+    expect(readPersistedSession(s, NOW)).toBeNull();
+  });
+
+  it("returns null when the stored value is malformed JSON", () => {
+    const s = fakeStorage({ "sb-abc-auth-token": "{not json" });
+    expect(readPersistedSession(s, NOW)).toBeNull();
+  });
+
+  it("returns null when the stored session is expired", () => {
+    const s = fakeStorage({ "sb-abc-auth-token": sessionJson(past) });
+    expect(readPersistedSession(s, NOW)).toBeNull();
+  });
+
+  it("returns null when the session lacks access_token or user", () => {
+    const s = fakeStorage({
+      "sb-abc-auth-token": JSON.stringify({ expires_at: future }),
+    });
+    expect(readPersistedSession(s, NOW)).toBeNull();
+  });
+
+  it("returns the session for a valid, non-expired sb-*-auth-token", () => {
+    const s = fakeStorage({ "sb-proj123-auth-token": sessionJson(future) });
+    const out = readPersistedSession(s, NOW);
+    expect(out).not.toBeNull();
+    expect(out!.access_token).toBe("at");
+    expect(out!.user.id).toBe("u1");
+  });
+
+  it("returns null for a legacy envelope whose inner session is expired", () => {
+    const s = fakeStorage({
+      "sb-x-auth-token": JSON.stringify({
+        currentSession: JSON.parse(sessionJson(past)),
+        expiresAt: future, // outer is deliberately ignored
+      }),
+    });
+    expect(readPersistedSession(s, NOW)).toBeNull();
+  });
+
+  it("unwraps the legacy { currentSession } envelope shape", () => {
+    const s = fakeStorage({
+      "sb-x-auth-token": JSON.stringify({
+        currentSession: JSON.parse(sessionJson(future)),
+        expiresAt: future,
+      }),
+    });
+    const out = readPersistedSession(s, NOW);
+    expect(out).not.toBeNull();
+    expect(out!.user.id).toBe("u1");
+  });
+});

--- a/vifrost/src/lib/persistedSession.ts
+++ b/vifrost/src/lib/persistedSession.ts
@@ -1,0 +1,63 @@
+import type { Session } from "@supabase/supabase-js"
+
+// supabase-js v2 persists the auth session in localStorage under a key
+// like `sb-<projectRef>-auth-token` (default storage). reading it
+// synchronously lets AuthContext start authed on refresh instead of
+// flashing a full-page loader while the async getSession() resolves.
+// this is optimistic: the async getSession()/onAuthStateChange still
+// runs and corrects (sign-out / redirect) if the stored session is
+// actually invalid server-side.
+
+const AUTH_TOKEN_KEY_RE = /^sb-.*-auth-token$/
+
+type StorageLike = {
+  length: number
+  key(index: number): string | null
+  getItem(key: string): string | null
+}
+
+function extractSession(parsed: unknown): Session | null {
+  if (!parsed || typeof parsed !== "object") return null
+  const o = parsed as Record<string, unknown>
+  // current v2 shape: the session object itself.
+  if (o.access_token && o.user) return o as unknown as Session
+  // legacy envelope: { currentSession, expiresAt }. the outer expiresAt
+  // is intentionally ignored — the caller validates the inner session's
+  // own expires_at, which is authoritative.
+  if (o.currentSession && typeof o.currentSession === "object") {
+    return o.currentSession as Session
+  }
+  return null
+}
+
+export function readPersistedSession(
+  storage: StorageLike | null | undefined,
+  nowMs: number = Date.now(),
+): Session | null {
+  if (!storage) return null
+  try {
+    let raw: string | null = null
+    for (let i = 0; i < storage.length; i++) {
+      const k = storage.key(i)
+      if (k && AUTH_TOKEN_KEY_RE.test(k)) {
+        raw = storage.getItem(k)
+        break
+      }
+    }
+    if (!raw) return null
+
+    const session = extractSession(JSON.parse(raw))
+    if (!session) return null
+
+    // expires_at is unix seconds. only treat a comfortably-valid session
+    // as authed; an expired token must fall back to the async refresh
+    // path so we never optimistically render a dead session.
+    if (typeof session.expires_at !== "number") return null
+    if (session.expires_at * 1000 <= nowMs) return null
+    if (!session.access_token || !session.user) return null
+
+    return session
+  } catch {
+    return null
+  }
+}

--- a/vifrost/src/types/profile.ts
+++ b/vifrost/src/types/profile.ts
@@ -10,6 +10,59 @@ export interface Profile {
   status: UserStatus
   created_at: string
   updated_at: string
+  rating: number
+  peak_rating: number
+  wins: number
+  losses: number
+  ties: number
+  current_streak: number
+}
+
+export interface MatchRecord {
+  id: string
+  created_at: string
+  room_id: string
+  mode: "ranked" | "casual"
+  player1_id: string
+  player2_id: string
+  player1_score: number
+  player2_score: number
+  winner_id: string | null
+  player1_rating_before: number
+  player1_rating_after: number
+  player2_rating_before: number
+  player2_rating_after: number
+  challenge: string
+  duration_seconds: number
+  // resolved by the get_match_history RPC (joins profiles, which the browser
+  // cannot read directly under select-own RLS). optional so direct `matches`
+  // reads / older callers still type-check.
+  player1_name?: string
+  player2_name?: string
+}
+
+export interface LeaderboardRow {
+  id: string
+  display_name: string
+  rating: number
+  wins: number
+  losses: number
+  ties: number
+}
+
+// safe public subset returned by get_public_profile(p_user) — no
+// email/role/status. shaped to satisfy the `wins` field deriveAchievements
+// reads, so it can flow through useProfileInsights like a Profile.
+export interface PublicProfile {
+  id: string
+  display_name: string
+  rating: number
+  peak_rating: number
+  wins: number
+  losses: number
+  ties: number
+  current_streak: number
+  created_at: string
 }
 
 export interface AdminStats {

--- a/vifrost/vitest.config.ts
+++ b/vifrost/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
Part of the #38 breakdown (1 of 7). Foundation layer for the match feature: session/profile persistence, AuthContext/ProfileContext updates, Navbar changes, and vitest/jsdom as the test runner. The match gameplay, auth pages, and profile/leaderboard PRs all build on this.

Verified: `tsc -b` clean, `vitest run` passing (17/17).