### PR TITLE
feat: live profile, leaderboard, and match history data

### DIFF
--- a/vifrost/src/components/GlobalLeaderboardTile.tsx
+++ b/vifrost/src/components/GlobalLeaderboardTile.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { flushSync } from "react-dom"
-import globalLeaderboardData from "../data/globalLeaderboard.json"
+import { useLeaderboard } from "@/hooks/useLeaderboard"
 import {
   LeaderboardRow,
   type LeaderboardRowData,
@@ -13,12 +13,6 @@ import { ProgressiveBlur } from "./ui/progressive-blur"
 export interface GlobalLeaderboardTileProps {
   currentUser: string
 }
-
-const ALL_ROWS: LeaderboardRowData[] =
-  globalLeaderboardData as LeaderboardRowData[]
-
-const TOP_THREE = ALL_ROWS.slice(0, 3)
-const REST = ALL_ROWS.slice(3)
 
 const PAGE_SIZE = 20
 
@@ -35,6 +29,25 @@ export function GlobalLeaderboardTile({ currentUser }: GlobalLeaderboardTileProp
   const scrollRef = useRef<HTMLDivElement>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
   const myRowRef = useRef<HTMLDivElement>(null)
+
+  const { data: leaderboardRows = [], isLoading } = useLeaderboard()
+
+  // adapt leaderboard rows to the shape LeaderboardRow/PodiumCard sub-components expect;
+  // rank is 1-based index; fields with no real backing (country, apm, change) use neutral values.
+  const ALL_ROWS: LeaderboardRowData[] = leaderboardRows.map((r, i) => ({
+    id: i + 1,
+    userId: r.id,
+    player: r.display_name,
+    country: "",
+    wins: r.wins,
+    losses: r.losses,
+    rating: r.rating,
+    apm: 0,
+    change: 0,
+  }))
+
+  const TOP_THREE = ALL_ROWS.slice(0, 3)
+  const REST = ALL_ROWS.slice(3)
 
   const myIndex = REST.findIndex((r) => r.player === currentUser)
   const myRowInRest = myIndex >= 0 ? REST[myIndex] : undefined
@@ -55,7 +68,15 @@ export function GlobalLeaderboardTile({ currentUser }: GlobalLeaderboardTileProp
     )
     io.observe(sentinel)
     return () => io.disconnect()
-  }, [visibleCount])
+  }, [visibleCount, REST.length])
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full flex-col gap-6">
+        <TileHeader title="Leaderboard" subtitle="Loading…" />
+      </div>
+    )
+  }
 
   const jumpToMe = () => {
     if (!myRowInRest || myIndex < 0) return
@@ -173,6 +194,16 @@ export function GlobalLeaderboardTile({ currentUser }: GlobalLeaderboardTileProp
             })}
             {visibleCount < REST.length ? (
               <div ref={sentinelRef} className="h-px" aria-hidden="true" />
+            ) : REST.length > 0 ? (
+              // terminal spacer: at least as tall as the bottom blur band
+              // (25% of the scroll viewport) so the last real player row can
+              // always scroll fully clear of the progressive blur.
+              <div
+                className="flex items-start justify-center pt-4 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--colorTextMuted)]"
+                style={{ minHeight: "max(112px, calc(25vh - 120px))" }}
+              >
+                No more players to show
+              </div>
             ) : null}
           </div>
         </div>

--- a/vifrost/src/components/MatchHistoryTile.tsx
+++ b/vifrost/src/components/MatchHistoryTile.tsx
@@ -1,13 +1,12 @@
 import { useMemo, useState } from "react"
 import { useOutletContext } from "react-router-dom"
 import type { AppOutletContext } from "../App"
-import matchHistoryData from "../data/matchHistory.json"
+import { useAuth } from "@/contexts/AuthContext"
+import { useMatchHistory } from "@/hooks/useMatchHistory"
 import { MatchFilterBar, type MatchFilter } from "./match/MatchFilterBar"
 import { MatchRow, type MatchRowData } from "./match/MatchRow"
 import { StatBlock } from "./ui/stat-block"
 import { TileHeader } from "./ui/tile-header"
-
-const MATCHES: MatchRowData[] = matchHistoryData as MatchRowData[]
 
 const COLUMN_GRID =
   "grid grid-cols-[72px_260px_1fr_90px_80px_80px_24px] gap-5 px-5 pb-2 pt-0"
@@ -30,11 +29,13 @@ function applyFilter(filter: MatchFilter, rows: MatchRowData[]): MatchRowData[] 
 export function MatchHistoryTile() {
   const { username } = useOutletContext<AppOutletContext>()
   const safeName = username ?? "Guest"
+  const { user } = useAuth()
+  const { data: MATCHES = [], isLoading } = useMatchHistory(user?.id)
 
   const [filter, setFilter] = useState<MatchFilter>("All")
-  const [expandedId, setExpandedId] = useState<string | null>(MATCHES[0]?.id ?? null)
+  const [expandedId, setExpandedId] = useState<string | null>(null)
 
-  const filtered = useMemo(() => applyFilter(filter, MATCHES), [filter])
+  const filtered = useMemo(() => applyFilter(filter, MATCHES), [filter, MATCHES])
 
   const summary = useMemo(() => {
     const wins = MATCHES.filter((m) => m.outcome === "W").length
@@ -61,7 +62,7 @@ export function MatchHistoryTile() {
       bestDiff,
       winRate,
     }
-  }, [])
+  }, [MATCHES])
 
   const streak = useMemo(() => {
     // Leading streak: consecutive Ws from index 0.
@@ -71,7 +72,15 @@ export function MatchHistoryTile() {
       else break
     }
     return n
-  }, [])
+  }, [MATCHES])
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full flex-col gap-7">
+        <TileHeader title="Match History" subtitle="Loading…" />
+      </div>
+    )
+  }
 
   return (
     <div className="flex w-full flex-col gap-7">

--- a/vifrost/src/components/PlayerProfileTile.tsx
+++ b/vifrost/src/components/PlayerProfileTile.tsx
@@ -1,8 +1,9 @@
 import type { User } from "@supabase/supabase-js"
+import type { PublicProfile } from "@/types/profile"
 import { useNavigate } from "react-router-dom"
 import { displayNameFromUser } from "@/lib/displayNameFromUser"
-import leaderboardData from "../data/globalLeaderboard.json"
 import profileData from "../data/profile.json"
+import { useProfile } from "@/contexts/ProfileContext"
 import { Achievement } from "./profile/Achievement"
 import { ActivityHeatmap } from "./profile/ActivityHeatmap"
 import { CommandBar } from "./profile/CommandBar"
@@ -11,11 +12,14 @@ import { RatingChart } from "./profile/RatingChart"
 import { Panel } from "./ui/panel"
 import { SectionLabel } from "./ui/section-label"
 import { StatBlock } from "./ui/stat-block"
+import { useProfileInsights } from "@/hooks/useProfileInsights"
 
 export interface PlayerProfileTileProps {
   username: string
   /** When present, header and identity reflect this Supabase account (signup profile). */
   user?: User | null
+  /** When present, render another player's public profile (no owner chrome). */
+  publicProfile?: PublicProfile | null
 }
 
 function accountHandleFromEmail(email: string | undefined): string {
@@ -49,24 +53,66 @@ function bioFromUser(user: User): string {
   return "New ViFrost player — your stats and achievements will appear as you play."
 }
 
-type LeaderboardRowLite = { player: string; rating: number }
-
-const LIFETIME_WINS = 72
-const LIFETIME_LOSSES = 41
-const LIFETIME_GAMES = LIFETIME_WINS + LIFETIME_LOSSES
-const LIFETIME_WIN_RATE = Math.round((LIFETIME_WINS / LIFETIME_GAMES) * 100)
-
 const ACHIEVEMENTS_EARNED = profileData.achievements.filter((a) => a.earned).length
 const ACHIEVEMENTS_TOTAL = 32 // static "X / 32" display — the full set is aspirational
 
-export function PlayerProfileTile({ username, user }: PlayerProfileTileProps) {
+// deterministic sample data so the unsigned demo/showcase view keeps its
+// populated look without faking signed-in stats.
+const DEMO_RATING_POINTS: number[] = (() => {
+  const pts: number[] = []
+  let r = 1200
+  for (let i = 0; i < 90; i++) {
+    r += Math.sin(i * 1.8) * 6 + 1.8
+    r = Math.max(900, Math.min(1650, r))
+    pts.push(Math.round(r))
+  }
+  pts.push(1482)
+  return pts
+})()
+
+const DEMO_HEATMAP = (() => {
+  const cells = Array.from({ length: 12 * 7 }, (_, i) => {
+    const v = (Math.sin(i * 2.31) + Math.cos(i * 0.77) + 2) / 4
+    return v < 0.45 ? 0 : v < 0.7 ? 1 : v < 0.87 ? 2 : v < 0.96 ? 3 : 4
+  })
+  // representative per-day count for the showcase tooltip (rough inverse of
+  // levelForCount); the demo heatmap is already synthetic by design.
+  const LEVEL_TO_COUNT = [0, 1, 2, 4, 7]
+  return {
+    cells,
+    counts: cells.map((lvl) => LEVEL_TO_COUNT[lvl]),
+    total: 84,
+    weeks: 12,
+  }
+})()
+
+export function PlayerProfileTile({ username, user, publicProfile }: PlayerProfileTileProps) {
   const navigate = useNavigate()
-  const rows = leaderboardData as LeaderboardRowLite[]
+  const { profile } = useProfile()
+  // hooks must run unconditionally; pass undefined args on the public path so
+  // the match-records query is disabled (useProfileInsights gates on !!userId)
+  const insights = useProfileInsights(
+    publicProfile ? undefined : user?.id,
+    publicProfile ? null : (profile ?? null),
+  )
+
+  if (publicProfile) {
+    return <PublicProfileBody publicProfile={publicProfile} />
+  }
+
+  // live stats from the signed-in user's profile; fall back to zero until loaded
+  const liveWins = profile?.wins ?? 0
+  const liveLosses = profile?.losses ?? 0
+  const liveTies = profile?.ties ?? 0
+  const liveGames = liveWins + liveLosses + liveTies
+  const liveWinRate = liveGames > 0 ? Math.round((liveWins / liveGames) * 100) : 0
+  const liveRating = profile?.rating ?? 400
+  const livePeak = profile?.peak_rating ?? 400
+  const liveStreak = profile?.current_streak ?? 0
 
   if (user) {
+    const earnedCount = insights.achievements.filter((a) => a.earned).length
     const displayName = displayNameFromUser(user)
-    const myRow = rows.find((r) => r.player === displayName)
-    const rating = myRow?.rating ?? 1000
     const handle = accountHandleFromEmail(user.email ?? undefined)
     const joined = joinedFromUser(user.created_at)
     const bio = bioFromUser(user)
@@ -78,37 +124,75 @@ export function PlayerProfileTile({ username, user }: PlayerProfileTileProps) {
           handle={handle}
           joined={joined}
           bio={bio}
-          rating={rating}
+          rating={liveRating}
         />
 
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
           <StatBlock
             label="Rating"
-            value={myRow ? rating.toLocaleString("en-US") : "—"}
-            sub={myRow ? "From leaderboard data" : "Unranked · play ranked to get listed"}
+            value={liveRating.toLocaleString("en-US")}
+            sub={`Peak ${livePeak.toLocaleString("en-US")}`}
             accent
           />
-          <StatBlock label="Percentile" value="—" sub="No ranked data yet" />
-          <StatBlock label="Win rate" value="—" sub="No ranked matches yet" />
-          <StatBlock label="Streak" value="—" sub="Win streaks show here" accent />
-          <StatBlock label="APM" value="—" sub="After your first games" />
-          <StatBlock label="Avg. match" value="—" sub="Median duration" />
+          <StatBlock
+            label="Percentile"
+            value={insights.percentile ?? "—"}
+            sub={insights.percentile ? "of ranked players" : "No ranked data yet"}
+          />
+          <StatBlock
+            label="Win Rate"
+            value={liveGames > 0 ? `${liveWinRate}%` : "—"}
+            sub={liveGames > 0 ? `${liveWins}W · ${liveLosses}L · ${liveTies}T` : "No ranked matches yet"}
+          />
+          <StatBlock
+            label="Streak"
+            value={liveStreak > 0 ? `${liveStreak}W` : "—"}
+            sub="Win streaks show here"
+            accent
+          />
+          <StatBlock label="APM" value="—" sub="Not tracked yet" />
+          <StatBlock label="Avg. match" value="—" sub="Not tracked yet" />
         </div>
 
-        <Panel>
-          <SectionLabel className="mb-2">Your ViFrost profile</SectionLabel>
-          <p className="m-0 max-w-[560px] text-sm leading-relaxed text-[var(--colorTextMuted)]">
-            Charts, command usage, activity heatmap, and achievements from the demo profile are hidden until we
-            sync real match data to your account. Jump into the lobby to start building your record.
-          </p>
-          <button
-            type="button"
-            onClick={() => navigate("/lobby")}
-            className="mt-4 cursor-pointer rounded-lg border border-[var(--colorCyan)] bg-[color-mix(in_srgb,var(--colorCyan)_18%,transparent)] px-4 py-2 font-mono text-sm font-medium text-[var(--colorCyan)] transition-colors hover:bg-[color-mix(in_srgb,var(--colorCyan)_28%,transparent)]"
-          >
-            Go to lobby →
-          </button>
-        </Panel>
+        <RatingChart points={insights.ratingPoints} />
+
+        <ActivityHeatmap
+          cells={insights.heatmap.cells}
+          counts={insights.heatmap.counts}
+          total={insights.heatmap.total}
+          weeks={insights.heatmap.weeks}
+        />
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.2fr_1fr]">
+          <Panel>
+            <SectionLabel className="mb-3.5">Most used commands</SectionLabel>
+            <p className="m-0 text-sm leading-relaxed text-[var(--colorTextMuted)]">
+              Command usage isn't tracked yet — it will appear here once
+              per-command stats are captured.
+            </p>
+          </Panel>
+
+          <Panel>
+            <div className="mb-3.5 flex items-baseline justify-between">
+              <SectionLabel>Achievements</SectionLabel>
+              <div className="font-mono text-[11px] text-[var(--colorTextMuted)]">
+                {earnedCount} / {insights.achievements.length}
+              </div>
+            </div>
+            <div className="flex flex-col gap-2">
+              {insights.achievements.map((a) => (
+                <Achievement
+                  key={a.title}
+                  glyph={a.glyph}
+                  title={a.title}
+                  sub={a.sub}
+                  earned={a.earned}
+                  locked={a.locked}
+                />
+              ))}
+            </div>
+          </Panel>
+        </div>
 
         <div className="mt-2 text-right">
           <button
@@ -123,8 +207,7 @@ export function PlayerProfileTile({ username, user }: PlayerProfileTileProps) {
     )
   }
 
-  const myRow = rows.find((r) => r.player === username)
-  const rating = myRow?.rating ?? 1482
+  const rating = liveRating
 
   return (
     <div className="flex w-full flex-col gap-4">
@@ -140,7 +223,7 @@ export function PlayerProfileTile({ username, user }: PlayerProfileTileProps) {
         <StatBlock
           label="Rating"
           value={rating.toLocaleString("en-US")}
-          sub={`Peak ${profileData.peak.toLocaleString("en-US")}`}
+          sub={`Peak ${livePeak.toLocaleString("en-US")}`}
           accent
         />
         <StatBlock
@@ -150,13 +233,13 @@ export function PlayerProfileTile({ username, user }: PlayerProfileTileProps) {
         />
         <StatBlock
           label="Win Rate"
-          value={`${LIFETIME_WIN_RATE}%`}
-          sub={`${LIFETIME_WINS}W · ${LIFETIME_LOSSES}L`}
+          value={liveGames > 0 ? `${liveWinRate}%` : "—"}
+          sub={liveGames > 0 ? `${liveWins}W · ${liveLosses}L · ${liveTies}T` : "No ranked matches yet"}
         />
         <StatBlock
           label="Streak"
-          value={`${profileData.streak}W`}
-          sub="current · peak 8W"
+          value={liveStreak > 0 ? `${liveStreak}W` : "—"}
+          sub="current streak"
           accent
         />
         <StatBlock
@@ -171,9 +254,14 @@ export function PlayerProfileTile({ username, user }: PlayerProfileTileProps) {
         />
       </div>
 
-      <RatingChart />
+      <RatingChart points={DEMO_RATING_POINTS} />
 
-      <ActivityHeatmap />
+      <ActivityHeatmap
+        cells={DEMO_HEATMAP.cells}
+        counts={DEMO_HEATMAP.counts}
+        total={DEMO_HEATMAP.total}
+        weeks={DEMO_HEATMAP.weeks}
+      />
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.2fr_1fr]">
         <Panel>
@@ -217,6 +305,108 @@ export function PlayerProfileTile({ username, user }: PlayerProfileTileProps) {
         >
           View full match history →
         </button>
+      </div>
+    </div>
+  )
+}
+
+function PublicProfileBody({
+  publicProfile,
+}: {
+  publicProfile: PublicProfile
+}) {
+  const insights = useProfileInsights(
+    publicProfile.id,
+    publicProfile,
+    "public",
+  )
+  const earnedCount = insights.achievements.filter((a) => a.earned).length
+
+  const wins = publicProfile.wins
+  const losses = publicProfile.losses
+  const ties = publicProfile.ties
+  const games = wins + losses + ties
+  const winRate = games > 0 ? Math.round((wins / games) * 100) : 0
+  const displayName = publicProfile.display_name
+  const handle = handleFromDisplayName(displayName)
+  const joined = joinedFromUser(publicProfile.created_at)
+  const bio = `${displayName}'s public profile.`
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <ProfileHeader
+        username={displayName}
+        handle={handle}
+        joined={joined}
+        bio={bio}
+        rating={publicProfile.rating}
+      />
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+        <StatBlock
+          label="Rating"
+          value={publicProfile.rating.toLocaleString("en-US")}
+          sub={`Peak ${publicProfile.peak_rating.toLocaleString("en-US")}`}
+          accent
+        />
+        <StatBlock
+          label="Percentile"
+          value={insights.percentile ?? "—"}
+          sub={insights.percentile ? "of ranked players" : "No ranked data yet"}
+        />
+        <StatBlock
+          label="Win Rate"
+          value={games > 0 ? `${winRate}%` : "—"}
+          sub={games > 0 ? `${wins}W · ${losses}L · ${ties}T` : "No ranked matches yet"}
+        />
+        <StatBlock
+          label="Streak"
+          value={publicProfile.current_streak > 0 ? `${publicProfile.current_streak}W` : "—"}
+          sub="Win streaks show here"
+          accent
+        />
+        <StatBlock label="APM" value="—" sub="Not tracked yet" />
+        <StatBlock label="Avg. match" value="—" sub="Not tracked yet" />
+      </div>
+
+      <RatingChart points={insights.ratingPoints} />
+
+      <ActivityHeatmap
+        cells={insights.heatmap.cells}
+        counts={insights.heatmap.counts}
+        total={insights.heatmap.total}
+        weeks={insights.heatmap.weeks}
+      />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.2fr_1fr]">
+        <Panel>
+          <SectionLabel className="mb-3.5">Most used commands</SectionLabel>
+          <p className="m-0 text-sm leading-relaxed text-[var(--colorTextMuted)]">
+            Command usage isn't tracked yet — it will appear here once
+            per-command stats are captured.
+          </p>
+        </Panel>
+
+        <Panel>
+          <div className="mb-3.5 flex items-baseline justify-between">
+            <SectionLabel>Achievements</SectionLabel>
+            <div className="font-mono text-[11px] text-[var(--colorTextMuted)]">
+              {earnedCount} / {insights.achievements.length}
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            {insights.achievements.map((a) => (
+              <Achievement
+                key={a.title}
+                glyph={a.glyph}
+                title={a.title}
+                sub={a.sub}
+                earned={a.earned}
+                locked={a.locked}
+              />
+            ))}
+          </div>
+        </Panel>
       </div>
     </div>
   )

--- a/vifrost/src/components/leaderboard/LeaderboardRow.tsx
+++ b/vifrost/src/components/leaderboard/LeaderboardRow.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from "react"
+import { Link } from "react-router-dom"
 import { cn } from "@/lib/utils"
 import { Avatar } from "../ui/avatar"
 import { ChangeBadge } from "../ui/change-badge"
@@ -6,6 +7,7 @@ import { TierBadge } from "../ui/tier-badge"
 
 export interface LeaderboardRowData {
   id: number
+  userId: string
   player: string
   country: string
   wins: number
@@ -45,9 +47,12 @@ export const LeaderboardRow = forwardRef<HTMLDivElement, LeaderboardRowProps>(
           <Avatar name={row.player} size={34} />
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <span className="truncate font-mono text-sm text-[var(--colorText)]">
+              <Link
+                to={`/profile/${row.userId}`}
+                className="truncate font-mono text-sm text-[var(--colorText)] underline-offset-4 hover:text-[var(--colorCyan)] hover:underline focus-visible:text-[var(--colorCyan)] focus-visible:underline"
+              >
                 {row.player}
-              </span>
+              </Link>
               {isYou ? (
                 <span className="rounded-[3px] border border-[color:var(--colorAccentBorder)] bg-[var(--colorCyanDim)] px-1.5 py-px font-mono text-[9px] font-bold tracking-[0.08em] text-[var(--colorCyan)]">
                   YOU

--- a/vifrost/src/components/leaderboard/PodiumCard.tsx
+++ b/vifrost/src/components/leaderboard/PodiumCard.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom"
 import { Avatar } from "../ui/avatar"
 import { ChangeBadge } from "../ui/change-badge"
 import { TierBadge } from "../ui/tier-badge"
@@ -9,6 +10,7 @@ const MEDAL_COLORS: Record<1 | 2 | 3, string> = {
 }
 
 export interface PodiumCardRow {
+  userId: string
   player: string
   country: string
   rating: number
@@ -72,7 +74,12 @@ export function PodiumCard({ row, position }: PodiumCardProps) {
         <Avatar name={row.player} size={44} />
         <div className="min-w-0 flex-1">
           <div className="truncate font-mono text-sm text-[var(--colorText)]">
-            {row.player}
+            <Link
+              to={`/profile/${row.userId}`}
+              className="hover:text-[var(--colorCyan)] hover:underline underline-offset-4 focus-visible:text-[var(--colorCyan)]"
+            >
+              {row.player}
+            </Link>
           </div>
           <div className="mt-0.5 flex items-center gap-2 font-mono text-[11px] text-[var(--colorTextMuted)]">
             <span>{row.country}</span>

--- a/vifrost/src/components/profile/Achievement.tsx
+++ b/vifrost/src/components/profile/Achievement.tsx
@@ -5,19 +5,29 @@ export interface AchievementProps {
   title: string
   sub: string
   earned: boolean
+  // true = no backing data is captured for this criterion yet. renders
+  // dimmed with a native tooltip; never shows earned styling.
+  locked?: boolean
 }
 
-export function Achievement({ glyph, title, sub, earned }: AchievementProps) {
+export function Achievement({
+  glyph,
+  title,
+  sub,
+  earned,
+  locked = false,
+}: AchievementProps) {
   return (
     <div
+      title={locked ? "Criteria not tracked yet" : undefined}
       className={cn(
         "flex items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors",
-        earned
+        earned && !locked
           ? "border-[color:var(--colorAccentBorder)]"
           : "border-[color:var(--colorBorder)] opacity-45",
       )}
       style={
-        earned
+        earned && !locked
           ? {
               backgroundImage:
                 "linear-gradient(135deg, var(--colorCyanDim) 0%, var(--colorAccentSoft) 35%, transparent 90%)",
@@ -28,7 +38,7 @@ export function Achievement({ glyph, title, sub, earned }: AchievementProps) {
       <div
         className={cn(
           "grid h-9 w-9 place-items-center rounded-lg border font-mono text-sm font-semibold",
-          earned
+          earned && !locked
             ? "border-[color:var(--colorAccentBorder)] bg-[var(--colorCyanDim)] text-[var(--colorCyan)]"
             : "border-[color:var(--colorBorder)] bg-[var(--colorSubtleBg)] text-[var(--colorTextMuted)]",
         )}

--- a/vifrost/src/components/profile/ActivityHeatmap.tsx
+++ b/vifrost/src/components/profile/ActivityHeatmap.tsx
@@ -1,12 +1,11 @@
+import { useRef, useState } from "react"
 import { Panel } from "../ui/panel"
 import { SectionLabel } from "../ui/section-label"
 
 const CELL = 11
 const GAP = 3
 
-const MONTHS = ["Nov","Dec","Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct"]
-
-// Heat progression: cyan (quiet days) pink (activity).
+// Heat progression: cyan (quiet days) -> pink (activity).
 const LEVEL_COLORS = [
   "color-mix(in srgb, var(--colorText) 6%, transparent)",
   "color-mix(in srgb, var(--colorCyan) 22%, transparent)",
@@ -15,28 +14,52 @@ const LEVEL_COLORS = [
   "var(--colorPink)",
 ]
 
-// 52 weeks × 7 days = 364 cells. Deterministic.
-const HEATMAP: number[] = Array.from({ length: 52 * 7 }, (_, i) => {
-  const r = (Math.sin(i * 2.31) + Math.cos(i * 0.77) + 2) / 4 // normalize to 0..1
-  if (r < 0.45) return 0
-  if (r < 0.70) return 1
-  if (r < 0.87) return 2
-  if (r < 0.96) return 3
-  return 4
-})
+export interface ActivityHeatmapProps {
+  cells: number[] // length weeks*7, value 0..4, index 0 = oldest day
+  // raw per-day match count, same indexing as cells. when present, each cell
+  // gets an instant hover tooltip with that day's match count.
+  counts?: number[]
+  total: number
+  weeks: number
+}
 
-const TOTAL_MATCHES = HEATMAP.reduce((a, v) => a + (v > 0 ? 1 : 0), 0)
+function matchLabel(n: number): string {
+  if (n <= 0) return "No matches"
+  return n === 1 ? "1 match" : `${n} matches`
+}
 
-export function ActivityHeatmap() {
-  const width = 52 * (CELL + GAP)
+interface HoverState {
+  x: number
+  y: number
+  n: number
+}
+
+export function ActivityHeatmap({
+  cells,
+  counts,
+  total,
+  weeks,
+}: ActivityHeatmapProps) {
+  const width = weeks * (CELL + GAP)
   const height = 7 * (CELL + GAP)
+  const gridRef = useRef<HTMLDivElement>(null)
+  const [hover, setHover] = useState<HoverState | null>(null)
+
+  // pointer position relative to the grid container so the tooltip can be
+  // absolutely positioned regardless of the svg's responsive scaling.
+  const trackPointer = (e: { clientX: number; clientY: number }, n: number) => {
+    const box = gridRef.current?.getBoundingClientRect()
+    if (!box) return
+    setHover({ x: e.clientX - box.left, y: e.clientY - box.top, n })
+  }
+
   return (
     <Panel>
       <div className="mb-4 flex items-baseline justify-between">
         <div>
           <SectionLabel>Activity</SectionLabel>
           <div className="mt-1 text-sm text-[var(--colorText)]">
-            {TOTAL_MATCHES} matches in the last year
+            {total} matches in the last {weeks} weeks
           </div>
         </div>
         <div className="flex items-center gap-1.5 font-mono text-[11px] text-[var(--colorTextMuted)]">
@@ -52,37 +75,55 @@ export function ActivityHeatmap() {
         </div>
       </div>
 
-      <div className="flex flex-col gap-1.5">
-        <div className="flex w-full font-mono text-[10px] text-[var(--colorTextMuted)]">
-          {MONTHS.map((m) => (
-            <div key={m} className="flex-1">
-              {m}
-            </div>
-          ))}
+      {total === 0 ? (
+        <div className="grid h-[98px] place-items-center font-mono text-[12px] text-[var(--colorTextMuted)]">
+          No match activity in the last {weeks} weeks.
         </div>
-        <svg
-          width="100%"
-          viewBox={`0 0 ${width} ${height}`}
-          preserveAspectRatio="xMidYMid meet"
-          className="block"
-        >
-          {HEATMAP.map((level, i) => {
-            const col = Math.floor(i / 7)
-            const row = i % 7
-            return (
-              <rect
-                key={i}
-                x={col * (CELL + GAP)}
-                y={row * (CELL + GAP)}
-                width={CELL}
-                height={CELL}
-                rx={2}
-                fill={LEVEL_COLORS[level]}
-              />
-            )
-          })}
-        </svg>
-      </div>
+      ) : (
+        <div ref={gridRef} className="relative">
+          <svg
+            width="100%"
+            viewBox={`0 0 ${width} ${height}`}
+            preserveAspectRatio="xMidYMid meet"
+            className="block"
+          >
+            {cells.map((level, i) => {
+              const col = Math.floor(i / 7)
+              const row = i % 7
+              const n = counts?.[i]
+              const interactive = n !== undefined
+              return (
+                <rect
+                  key={i}
+                  x={col * (CELL + GAP)}
+                  y={row * (CELL + GAP)}
+                  width={CELL}
+                  height={CELL}
+                  rx={2}
+                  fill={LEVEL_COLORS[level]}
+                  style={interactive ? { cursor: "pointer" } : undefined}
+                  onMouseEnter={
+                    interactive ? (e) => trackPointer(e, n) : undefined
+                  }
+                  onMouseMove={
+                    interactive ? (e) => trackPointer(e, n) : undefined
+                  }
+                  onMouseLeave={interactive ? () => setHover(null) : undefined}
+                />
+              )
+            })}
+          </svg>
+
+          {hover ? (
+            <div
+              className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-[color:var(--colorSoftBorder)] bg-[var(--colorPanel)] px-2 py-1 font-mono text-[11px] text-[var(--colorText)] shadow-md"
+              style={{ left: hover.x, top: hover.y - 8 }}
+            >
+              {matchLabel(hover.n)}
+            </div>
+          ) : null}
+        </div>
+      )}
     </Panel>
   )
 }

--- a/vifrost/src/components/profile/RatingChart.tsx
+++ b/vifrost/src/components/profile/RatingChart.tsx
@@ -2,48 +2,34 @@ import { useMemo, useState } from "react"
 import { Panel } from "../ui/panel"
 import { SectionLabel } from "../ui/section-label"
 
-const CURRENT_RATING = 1482
-
-// Deterministic rating history (120 points). Module-load; never changes.
-const RATING_HISTORY: number[] = (() => {
-  const points: number[] = []
-  let r = 1200
-  for (let i = 0; i < 120; i++) {
-    const noise = Math.sin(i * 1.8) * 22 + Math.sin(i * 0.47) * 14
-    r += noise * 0.3 + 1.8
-    r = Math.max(900, Math.min(1650, r))
-    points.push(r)
-  }
-  points.push(CURRENT_RATING)
-  return points
-})()
-
-type Period = "7d" | "30d" | "90d" | "All"
-const PERIOD_SLICE: Record<Period, number> = {
-  "7d": 7,
-  "30d": 30,
-  "90d": 90,
-  All: RATING_HISTORY.length,
+export interface RatingChartProps {
+  // the user's rating after each match, oldest -> newest.
+  points: number[]
 }
 
-export function RatingChart() {
-  const [period, setPeriod] = useState<Period>("90d")
+type Period = "7" | "30" | "90" | "All"
+const PERIOD_TAIL: Record<Period, number> = { "7": 7, "30": 30, "90": 90, All: Infinity }
+
+export function RatingChart({ points }: RatingChartProps) {
+  const [period, setPeriod] = useState<Period>("90")
 
   const slice = useMemo(() => {
-    const n = PERIOD_SLICE[period]
-    return RATING_HISTORY.slice(-n)
-  }, [period])
+    const n = PERIOD_TAIL[period]
+    return n === Infinity ? points : points.slice(-n)
+  }, [period, points])
 
   const delta = useMemo(() => {
     if (slice.length < 2) return 0
     return Math.round(slice[slice.length - 1] - slice[0])
   }, [slice])
 
+  const current = points.length ? points[points.length - 1] : 0
+
   const { path, area } = useMemo(() => {
     const w = 680,
       h = 180,
       pad = 8
-    if (slice.length === 0) return { path: "", area: "" }
+    if (slice.length < 2) return { path: "", area: "" }
     const max = Math.max(...slice)
     const min = Math.min(...slice)
     const range = max - min || 1
@@ -52,7 +38,9 @@ export function RatingChart() {
       const y = pad + (1 - (v - min) / range) * (h - pad * 2)
       return [x, y] as const
     })
-    const path = pts.map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)}`).join(" ")
+    const path = pts
+      .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)}`)
+      .join(" ")
     const area = `${path} L ${w - pad} ${h - pad} L ${pad} ${h - pad} Z`
     return { path, area }
   }, [slice])
@@ -62,26 +50,28 @@ export function RatingChart() {
       <div className="mb-3.5 flex items-baseline justify-between">
         <div>
           <SectionLabel>Rating · last {slice.length} matches</SectionLabel>
-          <div className="mt-1 font-mono text-[22px] text-[var(--colorText)]">
-            {CURRENT_RATING.toLocaleString("en-US")}{" "}
-            <span
-              className="text-[13px]"
-              style={{
-                color:
-                  delta > 0
-                    ? "var(--colorCyan)"
-                    : delta < 0
-                    ? "var(--colorDanger)"
-                    : "var(--colorTextMuted)",
-              }}
-            >
-              {delta > 0 ? "+" : ""}
-              {delta} {delta > 0 ? "↑" : delta < 0 ? "↓" : ""}
-            </span>
-          </div>
+          {points.length >= 2 && (
+            <div className="mt-1 font-mono text-[22px] text-[var(--colorText)]">
+              {current.toLocaleString("en-US")}{" "}
+              <span
+                className="text-[13px]"
+                style={{
+                  color:
+                    delta > 0
+                      ? "var(--colorCyan)"
+                      : delta < 0
+                      ? "var(--colorDanger)"
+                      : "var(--colorTextMuted)",
+                }}
+              >
+                {delta > 0 ? "+" : ""}
+                {delta} {delta > 0 ? "↑" : delta < 0 ? "↓" : ""}
+              </span>
+            </div>
+          )}
         </div>
         <div className="flex gap-1">
-          {(Object.keys(PERIOD_SLICE) as Period[]).map((p) => {
+          {(Object.keys(PERIOD_TAIL) as Period[]).map((p) => {
             const active = p === period
             return (
               <button
@@ -101,37 +91,38 @@ export function RatingChart() {
           })}
         </div>
       </div>
-      <svg
-        width="100%"
-        viewBox="0 0 680 180"
-        preserveAspectRatio="none"
-        className="block"
-      >
-        <defs>
-          <linearGradient id="ratingFill" x1="0" x2="1" y1="0" y2="1">
-            <stop offset="0%" stopColor="var(--colorCyan)" stopOpacity="0.32" />
-            <stop offset="55%" stopColor="var(--colorCyan)" stopOpacity="0.12" />
-            <stop offset="100%" stopColor="var(--colorPink)" stopOpacity="0.05" />
-          </linearGradient>
-          <linearGradient id="ratingStroke" x1="0" x2="1" y1="0" y2="0">
-            <stop offset="0%" stopColor="var(--colorCyan)" />
-            <stop offset="100%" stopColor="var(--colorPink)" />
-          </linearGradient>
-        </defs>
-        {[0.25, 0.5, 0.75].map((f) => (
-          <line
-            key={f}
-            x1={8}
-            x2={672}
-            y1={8 + f * 164}
-            y2={8 + f * 164}
-            stroke="var(--colorBorder)"
-            strokeDasharray="2 4"
-          />
-        ))}
-        <path d={area} fill="url(#ratingFill)" />
-        <path d={path} fill="none" stroke="url(#ratingStroke)" strokeWidth="1.5" />
-      </svg>
+      {slice.length < 2 ? (
+        <div className="grid h-[180px] place-items-center font-mono text-[12px] text-[var(--colorTextMuted)]">
+          Not enough matches yet to chart rating.
+        </div>
+      ) : (
+        <svg width="100%" viewBox="0 0 680 180" preserveAspectRatio="none" className="block">
+          <defs>
+            <linearGradient id="ratingFill" x1="0" x2="1" y1="0" y2="1">
+              <stop offset="0%" stopColor="var(--colorCyan)" stopOpacity="0.32" />
+              <stop offset="55%" stopColor="var(--colorCyan)" stopOpacity="0.12" />
+              <stop offset="100%" stopColor="var(--colorPink)" stopOpacity="0.05" />
+            </linearGradient>
+            <linearGradient id="ratingStroke" x1="0" x2="1" y1="0" y2="0">
+              <stop offset="0%" stopColor="var(--colorCyan)" />
+              <stop offset="100%" stopColor="var(--colorPink)" />
+            </linearGradient>
+          </defs>
+          {[0.25, 0.5, 0.75].map((f) => (
+            <line
+              key={f}
+              x1={8}
+              x2={672}
+              y1={8 + f * 164}
+              y2={8 + f * 164}
+              stroke="var(--colorBorder)"
+              strokeDasharray="2 4"
+            />
+          ))}
+          <path d={area} fill="url(#ratingFill)" />
+          <path d={path} fill="none" stroke="url(#ratingStroke)" strokeWidth="1.5" />
+        </svg>
+      )}
     </Panel>
   )
 }

--- a/vifrost/src/hooks/useLeaderboard.ts
+++ b/vifrost/src/hooks/useLeaderboard.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query"
+import { fetchLeaderboard } from "@/services/matchService"
+
+export const leaderboardQueryKey = ["leaderboard"] as const
+
+export function useLeaderboard() {
+  return useQuery({
+    queryKey: leaderboardQueryKey,
+    queryFn: fetchLeaderboard,
+  })
+}

--- a/vifrost/src/hooks/useMatchHistory.ts
+++ b/vifrost/src/hooks/useMatchHistory.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query"
+import { fetchMatchHistory } from "@/services/matchService"
+
+export const matchHistoryQueryKey = (userId: string | undefined) =>
+  ["matches", userId ?? "anon"] as const
+
+export function useMatchHistory(userId: string | undefined) {
+  return useQuery({
+    queryKey: matchHistoryQueryKey(userId),
+    queryFn: () => fetchMatchHistory(userId as string),
+    enabled: !!userId,
+  })
+}

--- a/vifrost/src/hooks/useProfileInsights.ts
+++ b/vifrost/src/hooks/useProfileInsights.ts
@@ -1,0 +1,68 @@
+import { useQuery } from "@tanstack/react-query"
+import {
+  fetchMatchRecords,
+  fetchPublicMatchRecords,
+} from "@/services/matchService"
+import { useLeaderboard } from "./useLeaderboard"
+import {
+  deriveAchievements,
+  deriveActivityHeatmap,
+  derivePercentile,
+  deriveRatingTimeline,
+  type AchievementView,
+  type HeatmapData,
+} from "@/lib/profileInsights"
+import type { Profile, PublicProfile } from "@/types/profile"
+
+export interface ProfileInsights {
+  ratingPoints: number[]
+  heatmap: HeatmapData
+  achievements: AchievementView[]
+  percentile: string | null
+  isLoading: boolean
+}
+
+export type RecordSource = "own" | "public"
+
+// pure: scoped react-query key so the auth-scoped own history and a public
+// player's history never share a cache entry. exported for unit testing.
+export function matchRecordsQuerySpec(
+  userId: string | undefined,
+  source: RecordSource = "own",
+) {
+  return {
+    queryKey: ["matchRecords", source, userId ?? "anon"] as const,
+    source,
+  }
+}
+
+// one match-history fetch (own = auth.uid()-scoped get_match_history;
+// public = get_public_match_history(userId)) + the shared leaderboard query,
+// run through the tested pure derivations. server i/o stays in services/hooks.
+export function useProfileInsights(
+  userId: string | undefined,
+  profile: Profile | PublicProfile | null,
+  source: RecordSource = "own",
+): ProfileInsights {
+  const spec = matchRecordsQuerySpec(userId, source)
+  const matches = useQuery({
+    queryKey: spec.queryKey,
+    queryFn: () =>
+      spec.source === "public" && userId
+        ? fetchPublicMatchRecords(userId)
+        : fetchMatchRecords(),
+    enabled: !!userId,
+  })
+  const leaderboard = useLeaderboard()
+
+  const records = matches.data ?? []
+  const rows = leaderboard.data ?? []
+
+  return {
+    ratingPoints: userId ? deriveRatingTimeline(records, userId) : [],
+    heatmap: deriveActivityHeatmap(records),
+    achievements: deriveAchievements(profile, records),
+    percentile: userId ? derivePercentile(rows, userId) : null,
+    isLoading: matches.isLoading || leaderboard.isLoading,
+  }
+}

--- a/vifrost/src/hooks/usePublicProfile.ts
+++ b/vifrost/src/hooks/usePublicProfile.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query"
+import { fetchPublicProfile } from "@/services/matchService"
+import type { PublicProfile } from "@/types/profile"
+
+export const publicProfileQueryKey = (userId: string | undefined) =>
+  ["publicProfile", userId ?? "none"] as const
+
+export interface UsePublicProfileResult {
+  profile: PublicProfile | null
+  isLoading: boolean
+  isError: boolean
+  // true only once the query has resolved and returned no row (vs. still
+  // loading or erroring) — drives the honest "Player not found" panel.
+  notFound: boolean
+}
+
+// server i/o stays in services/hooks; the component consumes this hook only.
+export function usePublicProfile(
+  userId: string | undefined,
+): UsePublicProfileResult {
+  const q = useQuery({
+    queryKey: publicProfileQueryKey(userId),
+    queryFn: () => fetchPublicProfile(userId as string),
+    enabled: !!userId,
+  })
+  return {
+    profile: q.data ?? null,
+    isLoading: q.isLoading,
+    isError: q.isError,
+    notFound: q.isSuccess && q.data == null,
+  }
+}

--- a/vifrost/src/lib/profileInsights.test.ts
+++ b/vifrost/src/lib/profileInsights.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest"
+import { deriveRatingTimeline } from "./profileInsights"
+import type { MatchRecord } from "@/types/profile"
+import { matchRecordsQuerySpec } from "@/hooks/useProfileInsights"
+
+function rec(over: Partial<MatchRecord>): MatchRecord {
+  return {
+    id: "x",
+    created_at: "2026-01-01T00:00:00Z",
+    room_id: "r",
+    mode: "ranked",
+    player1_id: "me",
+    player2_id: "foe",
+    player1_score: 0,
+    player2_score: 0,
+    winner_id: null,
+    player1_rating_before: 400,
+    player1_rating_after: 400,
+    player2_rating_before: 400,
+    player2_rating_after: 400,
+    challenge: "c",
+    duration_seconds: 120,
+    ...over,
+  }
+}
+
+describe("deriveRatingTimeline", () => {
+  it("returns the user's rating_after oldest->newest, picking the right side", () => {
+    const records = [
+      rec({ created_at: "2026-01-03T00:00:00Z", player1_id: "me", player1_rating_after: 430 }),
+      rec({ created_at: "2026-01-01T00:00:00Z", player1_id: "me", player1_rating_after: 410 }),
+      rec({ created_at: "2026-01-02T00:00:00Z", player1_id: "foe", player2_id: "me", player2_rating_after: 420 }),
+    ]
+    expect(deriveRatingTimeline(records, "me")).toEqual([410, 420, 430])
+  })
+
+  it("returns [] for no records", () => {
+    expect(deriveRatingTimeline([], "me")).toEqual([])
+  })
+
+  it("excludes records where userId is neither player", () => {
+    const unrelated = rec({ player1_id: "a", player2_id: "b", player1_rating_after: 999, player2_rating_after: 888 })
+    expect(deriveRatingTimeline([unrelated], "me")).toEqual([])
+  })
+})
+
+import { deriveActivityHeatmap } from "./profileInsights"
+
+describe("deriveActivityHeatmap", () => {
+  const now = new Date("2026-05-19T12:00:00Z")
+
+  it("cells length = weeks*7 and total counts only in-window matches", () => {
+    const records = [
+      rec({ created_at: "2026-05-19T01:00:00Z" }), // today
+      rec({ created_at: "2026-05-19T05:00:00Z" }), // today
+      rec({ created_at: "2026-01-01T00:00:00Z" }), // outside 12wk window
+    ]
+    const h = deriveActivityHeatmap(records, 12, now)
+    expect(h.cells.length).toBe(84)
+    expect(h.weeks).toBe(12)
+    expect(h.total).toBe(2)
+    expect(h.cells[h.cells.length - 1]).toBe(2) // last cell = today, 2 matches -> level 2
+  })
+
+  it("maps count to level: 1->1, 2->2, 3->3, 4->3, 5->4", () => {
+    const day = (n: number) =>
+      Array.from({ length: n }, () => rec({ created_at: "2026-05-18T09:00:00Z" }))
+    expect(deriveActivityHeatmap(day(1), 12, now).cells.at(-2)).toBe(1)
+    expect(deriveActivityHeatmap(day(2), 12, now).cells.at(-2)).toBe(2)
+    expect(deriveActivityHeatmap(day(3), 12, now).cells.at(-2)).toBe(3)
+    expect(deriveActivityHeatmap(day(4), 12, now).cells.at(-2)).toBe(3)
+    expect(deriveActivityHeatmap(day(5), 12, now).cells.at(-2)).toBe(4)
+  })
+
+  it("empty records -> all zero cells, total 0", () => {
+    const h = deriveActivityHeatmap([], 12, now)
+    expect(h.total).toBe(0)
+    expect(h.cells.every((c) => c === 0)).toBe(true)
+  })
+
+  it("exposes raw per-day counts (unclamped, same indexing as cells)", () => {
+    const day = (n: number) =>
+      Array.from({ length: n }, () => rec({ created_at: "2026-05-18T09:00:00Z" }))
+    const h = deriveActivityHeatmap(day(5), 12, now)
+    expect(h.counts.length).toBe(h.cells.length)
+    // yesterday cell holds the raw 5 while the level is clamped to 4
+    expect(h.counts.at(-2)).toBe(5)
+    expect(h.cells.at(-2)).toBe(4)
+    // a day with no matches is 0 in counts too
+    expect(h.counts.at(-1)).toBe(0)
+    expect(deriveActivityHeatmap([], 12, now).counts.every((c) => c === 0)).toBe(
+      true,
+    )
+  })
+})
+
+import { deriveAchievements } from "./profileInsights"
+import type { Profile } from "@/types/profile"
+
+function prof(over: Partial<Profile>): Profile {
+  return {
+    id: "me",
+    email: "a@b.c",
+    full_name: null,
+    role: "user",
+    status: "approved",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    rating: 400,
+    peak_rating: 400,
+    wins: 0,
+    losses: 0,
+    ties: 0,
+    current_streak: 0,
+    ...over,
+  }
+}
+
+describe("deriveAchievements", () => {
+  it("returns all 5 in order; 3 are permanently locked", () => {
+    const a = deriveAchievements(prof({}), [])
+    expect(a.map((x) => x.title)).toEqual([
+      "Lightning Fingers",
+      "Hundred Club",
+      "Marathon",
+      "Flawless",
+      "Macro Master",
+    ])
+    expect(a[0].locked).toBe(true)
+    expect(a[3].locked).toBe(true)
+    expect(a[4].locked).toBe(true)
+    expect(a.filter((x) => x.locked).every((x) => x.earned === false)).toBe(true)
+  })
+
+  it("Hundred Club earned at >=100 wins, not at 99", () => {
+    expect(deriveAchievements(prof({ wins: 99 }), [])[1].earned).toBe(false)
+    expect(deriveAchievements(prof({ wins: 100 }), [])[1].earned).toBe(true)
+  })
+
+  it("Marathon earned when a calendar day has >=50 matches", () => {
+    const same = Array.from({ length: 50 }, () =>
+      rec({ created_at: "2026-05-10T08:00:00Z" }),
+    )
+    expect(deriveAchievements(prof({}), same)[2].earned).toBe(true)
+    const fewer = Array.from({ length: 49 }, () =>
+      rec({ created_at: "2026-05-10T08:00:00Z" }),
+    )
+    expect(deriveAchievements(prof({}), fewer)[2].earned).toBe(false)
+  })
+
+  it("Marathon: 50 records at 23:30Z all count as one UTC day", () => {
+    // timestamps straddle local midnight in many timezones but are all 2026-05-10 in UTC
+    const same = Array.from({ length: 50 }, () =>
+      rec({ created_at: "2026-05-10T23:30:00Z" }),
+    )
+    expect(deriveAchievements(prof({}), same)[2].earned).toBe(true)
+  })
+
+  it("handles null profile", () => {
+    expect(deriveAchievements(null, [])[1].earned).toBe(false)
+  })
+})
+
+import { derivePercentile } from "./profileInsights"
+import type { LeaderboardRow } from "@/types/profile"
+
+function lb(ids: string[]): LeaderboardRow[] {
+  return ids.map((id, i) => ({
+    id,
+    display_name: id,
+    rating: 1000 - i,
+    wins: 0,
+    losses: 0,
+    ties: 0,
+  }))
+}
+
+describe("derivePercentile", () => {
+  it("rank 1 of 100 -> Top 1%", () => {
+    const rows = lb(Array.from({ length: 100 }, (_, i) => `p${i}`))
+    expect(derivePercentile(rows, "p0")).toBe("Top 1%")
+  })
+
+  it("midway rank rounds", () => {
+    const rows = lb(Array.from({ length: 100 }, (_, i) => `p${i}`))
+    expect(derivePercentile(rows, "p49")).toBe("Top 50%")
+  })
+
+  it("not in ladder -> null", () => {
+    expect(derivePercentile(lb(["a", "b"]), "me")).toBeNull()
+  })
+
+  it("single-row ladder, user present -> Top 100%", () => {
+    expect(derivePercentile(lb(["me"]), "me")).toBe("Top 100%")
+  })
+
+  it("last place in a full 100-row ladder -> Top 100%", () => {
+    const rows = lb(Array.from({ length: 100 }, (_, i) => `p${i}`))
+    expect(derivePercentile(rows, "p99")).toBe("Top 100%")
+  })
+})
+
+describe("matchRecordsQuerySpec", () => {
+  it("scopes the query key by source so own vs public never collide", () => {
+    const own = matchRecordsQuerySpec("u1", "own")
+    const pub = matchRecordsQuerySpec("u1", "public")
+    expect(own.queryKey).toEqual(["matchRecords", "own", "u1"])
+    expect(pub.queryKey).toEqual(["matchRecords", "public", "u1"])
+  })
+  it("uses 'anon' when no user id is given and defaults scope to own", () => {
+    const spec = matchRecordsQuerySpec(undefined)
+    expect(spec.queryKey).toEqual(["matchRecords", "own", "anon"])
+  })
+})

--- a/vifrost/src/lib/profileInsights.ts
+++ b/vifrost/src/lib/profileInsights.ts
@@ -1,0 +1,111 @@
+import type {
+  LeaderboardRow,
+  MatchRecord,
+  Profile,
+} from "@/types/profile"
+
+// the signed-in user's rating after each match, oldest -> newest.
+export function deriveRatingTimeline(
+  records: MatchRecord[],
+  userId: string,
+): number[] {
+  return [...records]
+    .filter((m) => m.player1_id === userId || m.player2_id === userId)
+    .sort(
+      (a, b) =>
+        new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    )
+    .map((m) =>
+      m.player1_id === userId
+        ? m.player1_rating_after
+        : m.player2_rating_after,
+    )
+}
+
+export interface HeatmapData {
+  cells: number[]
+  // raw per-day match count, same length/indexing as cells (cells is the
+  // clamped 0..4 level; counts is the unclamped real number, for tooltips).
+  counts: number[]
+  total: number
+  weeks: number
+}
+
+function startOfDay(d: Date): number {
+  const x = new Date(d)
+  x.setUTCHours(0, 0, 0, 0)
+  return x.getTime()
+}
+
+function levelForCount(c: number): number {
+  if (c <= 0) return 0
+  if (c === 1) return 1
+  if (c === 2) return 2
+  if (c <= 4) return 3
+  return 4
+}
+
+// daily activity for the last `weeks*7` days ending on `now`. cells[0] is the
+// oldest day, the last cell is today. matches outside the window are ignored.
+export function deriveActivityHeatmap(
+  records: MatchRecord[],
+  weeks = 12,
+  now: Date = new Date(),
+): HeatmapData {
+  const days = weeks * 7
+  const counts = new Array<number>(days).fill(0)
+  const todayStart = startOfDay(now)
+  const DAY = 86_400_000
+  let total = 0
+  for (const m of records) {
+    const dayStart = startOfDay(new Date(m.created_at))
+    const offset = Math.round((todayStart - dayStart) / DAY)
+    if (offset < 0 || offset >= days) continue
+    counts[days - 1 - offset]++
+    total++
+  }
+  return { cells: counts.map(levelForCount), counts, total, weeks }
+}
+
+export interface AchievementView {
+  glyph: string
+  title: string
+  sub: string
+  earned: boolean
+  locked: boolean
+}
+
+// the original 5 demo achievements. only the two that map to real data are
+// evaluated; the rest are permanently locked (no backing data captured yet).
+export function deriveAchievements(
+  profile: Pick<Profile, "wins"> | null,
+  records: MatchRecord[],
+): AchievementView[] {
+  const wins = profile?.wins ?? 0
+  const byDay = new Map<string, number>()
+  for (const m of records) {
+    const key = m.created_at.slice(0, 10)
+    byDay.set(key, (byDay.get(key) ?? 0) + 1)
+  }
+  const maxInADay = byDay.size ? Math.max(...byDay.values()) : 0
+  return [
+    { glyph: "⚡", title: "Lightning Fingers", sub: "Not tracked yet", earned: false, locked: true },
+    { glyph: "✓", title: "Hundred Club", sub: "Win 100 ranked matches", earned: wins >= 100, locked: false },
+    { glyph: "∞", title: "Marathon", sub: "Play 50 matches in a day", earned: maxInADay >= 50, locked: false },
+    { glyph: "△", title: "Flawless", sub: "Not tracked yet", earned: false, locked: true },
+    { glyph: "※", title: "Macro Master", sub: "Not tracked yet", earned: false, locked: true },
+  ]
+}
+
+// percentile from leaderboard position (rows are already rating desc).
+// null when the user is not in the ladder. caveat: the ladder is capped at
+// 100, so this is relative to the top 100 only.
+export function derivePercentile(
+  rows: LeaderboardRow[],
+  userId: string,
+): string | null {
+  const idx = rows.findIndex((r) => r.id === userId)
+  if (idx < 0) return null
+  const pct = Math.max(1, Math.round(((idx + 1) / rows.length) * 100))
+  return `Top ${pct}%`
+}

--- a/vifrost/src/main.tsx
+++ b/vifrost/src/main.tsx
@@ -22,6 +22,7 @@ import { PendingApprovalPage } from "./pages/PendingApprovalPage.tsx"
 import { BannedPage, RejectedPage } from "./pages/AccountRestrictedPage.tsx"
 import { UnauthorizedPage } from "./pages/UnauthorizedPage.tsx"
 import { AdminDashboardPage } from "./pages/AdminDashboardPage.tsx"
+import { PublicProfilePage } from "./pages/PublicProfilePage.tsx"
 import { ApprovedRoute } from "./components/guards/ApprovedRoute.tsx"
 import { AdminRoute } from "./components/guards/AdminRoute.tsx"
 import { ProtectedRoute } from "./components/guards/ProtectedRoute.tsx"
@@ -66,6 +67,14 @@ const router = createBrowserRouter([
         element: (
           <ProtectedRoute>
             <ProfilePage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "profile/:userId",
+        element: (
+          <ProtectedRoute>
+            <PublicProfilePage />
           </ProtectedRoute>
         ),
       },

--- a/vifrost/src/pages/PublicProfilePage.tsx
+++ b/vifrost/src/pages/PublicProfilePage.tsx
@@ -1,0 +1,39 @@
+import { useParams } from "react-router-dom"
+import { usePublicProfile } from "../hooks/usePublicProfile"
+import { PlayerProfileTile } from "../components/PlayerProfileTile"
+import { PageShell } from "../components/ui/page-shell"
+import { Panel } from "../components/ui/panel"
+
+export function PublicProfilePage() {
+  const { userId } = useParams<{ userId: string }>()
+  const { profile, isLoading, isError, notFound } = usePublicProfile(userId)
+
+  return (
+    <PageShell>
+      {isLoading ? (
+        <Panel>
+          <p className="m-0 text-sm text-[var(--colorTextMuted)]">
+            Loading profile…
+          </p>
+        </Panel>
+      ) : notFound ? (
+        <Panel>
+          <p className="m-0 text-sm text-[var(--colorTextMuted)]">
+            Player not found.
+          </p>
+        </Panel>
+      ) : isError || !profile ? (
+        <Panel>
+          <p className="m-0 text-sm text-[var(--colorTextMuted)]">
+            Couldn't load this profile right now. Try again later.
+          </p>
+        </Panel>
+      ) : (
+        <PlayerProfileTile
+          username={profile.display_name}
+          publicProfile={profile}
+        />
+      )}
+    </PageShell>
+  )
+}

--- a/vifrost/src/services/matchService.test.ts
+++ b/vifrost/src/services/matchService.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest"
+import {
+  toMatchRow,
+  fetchMatchRecords,
+  firstPublicProfile,
+  fetchPublicProfile,
+  fetchPublicMatchRecords,
+} from "./matchService"
+import type { MatchRecord, PublicProfile } from "@/types/profile"
+
+const base: MatchRecord = {
+  id: "m1",
+  created_at: new Date().toISOString(),
+  room_id: "room-1",
+  mode: "ranked",
+  player1_id: "me",
+  player2_id: "foe",
+  player1_score: 900,
+  player2_score: 400,
+  winner_id: "me",
+  player1_rating_before: 400,
+  player1_rating_after: 416,
+  player2_rating_before: 400,
+  player2_rating_after: 384,
+  challenge: "reverse a list",
+  duration_seconds: 73,
+  player1_name: "Ada",
+  player2_name: "Linus",
+}
+
+describe("toMatchRow", () => {
+  it("derives a win + positive delta from player1's view", () => {
+    const row = toMatchRow(base, "me")
+    expect(row.outcome).toBe("W")
+    expect(row.ratingChange).toBe(16)
+    expect(row.opponent).toBe("Linus")
+    expect(row.mode).toBe("Ranked")
+  })
+
+  it("derives a loss + negative delta from player2's view", () => {
+    const row = toMatchRow(base, "foe")
+    expect(row.outcome).toBe("L")
+    expect(row.ratingChange).toBe(-16)
+    expect(row.opponent).toBe("Ada")
+  })
+
+  it("derives a tie when winner_id is null", () => {
+    const row = toMatchRow({ ...base, winner_id: null }, "me")
+    expect(row.outcome).toBe("D")
+  })
+
+  it("falls back to a short id when no opponent name is present", () => {
+    const noNames: MatchRecord = {
+      ...base,
+      player2_id: "abcdef123456",
+      player1_name: undefined,
+      player2_name: undefined,
+    }
+    expect(toMatchRow(noNames, "me").opponent).toBe("abcdef")
+  })
+})
+
+describe("fetchMatchRecords", () => {
+  it("is exported as a function", () => {
+    expect(typeof fetchMatchRecords).toBe("function")
+  })
+})
+
+const pub: PublicProfile = {
+  id: "u1",
+  display_name: "Ada",
+  rating: 1200,
+  peak_rating: 1300,
+  wins: 10,
+  losses: 4,
+  ties: 1,
+  current_streak: 3,
+  created_at: new Date("2026-01-02").toISOString(),
+}
+
+describe("firstPublicProfile", () => {
+  it("returns the first row when the RPC returned rows", () => {
+    expect(firstPublicProfile([pub])).toEqual(pub)
+  })
+  it("returns null for an empty array (player not found)", () => {
+    expect(firstPublicProfile([])).toBeNull()
+  })
+  it("returns null for null/undefined data", () => {
+    expect(firstPublicProfile(null)).toBeNull()
+    expect(firstPublicProfile(undefined)).toBeNull()
+  })
+})
+
+describe("fetchPublicProfile / fetchPublicMatchRecords", () => {
+  it("are exported as functions", () => {
+    expect(typeof fetchPublicProfile).toBe("function")
+    expect(typeof fetchPublicMatchRecords).toBe("function")
+  })
+})

--- a/vifrost/src/services/matchService.ts
+++ b/vifrost/src/services/matchService.ts
@@ -1,0 +1,95 @@
+import { requireSupabase } from "@/lib/supabase"
+import type { LeaderboardRow, MatchRecord, PublicProfile } from "@/types/profile"
+import type { MatchRowData } from "@/components/match/MatchRow"
+
+// pure mapping from a symmetric match row to the current user's perspective.
+// no network here so it is unit-testable in isolation.
+export function toMatchRow(m: MatchRecord, userId: string): MatchRowData {
+  const isP1 = m.player1_id === userId
+  const before = isP1 ? m.player1_rating_before : m.player2_rating_before
+  const after = isP1 ? m.player1_rating_after : m.player2_rating_after
+  const outcome: MatchRowData["outcome"] =
+    m.winner_id === null ? "D" : m.winner_id === userId ? "W" : "L"
+  const youScore = isP1 ? m.player1_score : m.player2_score
+  const oppScore = isP1 ? m.player2_score : m.player1_score
+  // get_match_history resolves these via a security-definer join; fall back to
+  // a short id slice if a name is missing (e.g. a raw `matches` read).
+  const oppName = isP1 ? m.player2_name : m.player1_name
+  const oppId = isP1 ? m.player2_id : m.player1_id
+  return {
+    id: m.id.slice(0, 6),
+    outcome,
+    mode: m.mode === "ranked" ? "Ranked" : "Casual",
+    challenge: m.challenge || "Practice",
+    opponent: oppName || oppId.slice(0, 6),
+    oppRating: isP1 ? m.player2_rating_after : m.player1_rating_after,
+    ratingChange: after - before,
+    you: { keystrokes: youScore, time: m.duration_seconds, wpm: 0 },
+    opp: { keystrokes: oppScore, time: m.duration_seconds, wpm: 0 },
+    when: new Date(m.created_at).toLocaleDateString(),
+  }
+}
+
+export async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
+  const sb = requireSupabase()
+  // get_leaderboard is a security definer function (not a view): it returns
+  // only safe columns and already orders by rating desc, limit 100.
+  const { data, error } = await sb.rpc("get_leaderboard")
+  if (error) throw error
+  return (data ?? []) as LeaderboardRow[]
+}
+
+export async function fetchMatchHistory(
+  userId: string,
+): Promise<MatchRowData[]> {
+  const sb = requireSupabase()
+  // get_match_history is a security-definer RPC: it scopes rows to the caller
+  // (auth.uid()) and resolves opponent display names, which a direct `matches`
+  // read cannot do under select-own profiles RLS.
+  const { data, error } = await sb.rpc("get_match_history")
+  if (error) throw error
+  return ((data ?? []) as MatchRecord[]).map((m) => toMatchRow(m, userId))
+}
+
+// raw match rows (no per-row perspective mapping) for profile insights.
+// same single get_match_history RPC as fetchMatchHistory; additive.
+export async function fetchMatchRecords(): Promise<MatchRecord[]> {
+  const sb = requireSupabase()
+  const { data, error } = await sb.rpc("get_match_history")
+  if (error) throw error
+  return (data ?? []) as MatchRecord[]
+}
+
+// pure: the public-profile RPC returns an array; one row = found, zero = not
+// found. no network here so it is unit-testable.
+export function firstPublicProfile(
+  data: PublicProfile[] | null | undefined,
+): PublicProfile | null {
+  return data && data.length > 0 ? data[0] : null
+}
+
+// another player's safe profile. authenticated-only RPC (same grants as
+// get_match_history). null when the id has no profile row (not found).
+export async function fetchPublicProfile(
+  userId: string,
+): Promise<PublicProfile | null> {
+  const sb = requireSupabase()
+  const { data, error } = await sb.rpc("get_public_profile", {
+    p_user: userId,
+  })
+  if (error) throw error
+  return firstPublicProfile(data as PublicProfile[] | null)
+}
+
+// another player's recent (last 50) matches (raw records, same shape/type as
+// fetchMatchRecords) for the public profile insights.
+export async function fetchPublicMatchRecords(
+  userId: string,
+): Promise<MatchRecord[]> {
+  const sb = requireSupabase()
+  const { data, error } = await sb.rpc("get_public_match_history", {
+    p_user: userId,
+  })
+  if (error) throw error
+  return (data ?? []) as MatchRecord[]
+}


### PR DESCRIPTION
Part of the #38 breakdown (6 of 7). Stacked on #42 (match gameplay UI), needed for the AppOutletContext type used by MatchHistoryTile. Wires PlayerProfileTile, GlobalLeaderboardTile, and MatchHistoryTile to live Supabase data, adds a public profile page, and profile insight aggregation (rating chart, activity heatmap, achievements).

Verified: `tsc -b` clean, `vitest run` passing (108/108).