### PR TITLE
feat: light mode color tweak and animate-ui registry

### DIFF
--- a/vifrost/components.json
+++ b/vifrost/components.json
@@ -23,6 +23,7 @@
   },
   "registries": {
     "@magicui": "https://magicui.design/r/{name}",
-    "@react-bits": "https://reactbits.dev/r/{name}.json"
+    "@react-bits": "https://reactbits.dev/r/{name}.json",
+    "@animate-ui": "https://animate-ui.com/r/{name}.json"
   }
 }

--- a/vifrost/src/index.css
+++ b/vifrost/src/index.css
@@ -57,7 +57,7 @@
   --colorSurfaceAlt: #e2eeec;
   --colorBorder: #b8d0cc;
   --colorText: #0f2832;
-  --colorTextMuted: #4a7a72;
+  --colorTextMuted: #38605a;
   --colorAccent: #646cff;
   --colorAccentHover: #535bf2;
   --colorDanger: #ef4444;
@@ -241,3 +241,45 @@ button:focus-visible {
     @apply font-sans;
   }
 }
+
+/* route page-transition overlay (see src/providers/TransitionProvider.tsx).
+   strokes point at theme tokens, so the colours auto-swap with .dark. */
+:root {
+  --transition-stroke-1: var(--colorPink);
+  --transition-stroke-2: var(--colorCyan);
+}
+
+.transition-svg {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+.transition-svg--active {
+  pointer-events: auto;
+}
+
+.transition-backdrop {
+  position: absolute;
+  inset: 0;
+  background-color: var(--colorMain);
+  opacity: 0;
+}
+
+.transition-svg svg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 100%;
+  transform: translate(-50%, -50%) scale(1.5);
+}
+
+.transition-svg path {
+  stroke-dashoffset: 99999;
+  stroke-dasharray: 99999;
+}
+


### PR DESCRIPTION
Part of the #38 breakdown (7 of 7). Independent of the rest of the stack. Makes light mode muted text less washed out, adds the animate-ui shadcn registry, and adds the page-transition overlay styling used by TransitionProvider (component logic lands in #42).

Verified: `tsc -b` clean.